### PR TITLE
Add wrapper for `typeof` operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ and its current state in this package.
 | Number()             | --        | See note below              |
 | String()             | --        | Use js.Object.String()      |
 | unescape()           | --        | deprecated circa 2000       |
+| typeof operator      | yes       |                             |
 
 #### Notes on unmplemented functions
 
@@ -55,7 +56,7 @@ and its current state in this package.
 Get or update this package and dependencies with:
 
 ```
-go get -u github.com/gopherjs/jsbuiltin
+go get -u -d -tags=js github.com/gopherjs/jsbuiltin
 ```
 
 ### Basic usage example

--- a/jsbuiltin.go
+++ b/jsbuiltin.go
@@ -62,3 +62,22 @@ func IsFinite(value interface{}) bool {
 func IsNaN(value interface{}) bool {
 	return js.Global.Call("isNaN", value).Bool()
 }
+
+var typeOfFunc *js.Object
+
+func initTypeOf() {
+	typeOfFunc = js.Global.Call("eval", `(function() {
+			return function (x) {
+				return typeof x
+			}
+		})()
+	`)
+}
+
+// TypeOf returns the JavaScript type of the passed value
+func TypeOf(value interface{}) string {
+	if typeOfFunc == nil {
+		initTypeOf()
+	}
+	return typeOfFunc.Invoke(value).String()
+}

--- a/jsbuiltin_test.go
+++ b/jsbuiltin_test.go
@@ -3,6 +3,8 @@ package jsbuiltin
 
 import (
 	"testing"
+
+	"github.com/gopherjs/gopherjs/js"
 )
 
 func TestEncodeURI(t *testing.T) {
@@ -135,4 +137,37 @@ func TestIsNaN(t *testing.T) {
 			t.Fatalf("IsNaN(%s) returned %t, not %t", value, result, expected)
 		}
 	}
+}
+
+func TestTypeOf(t *testing.T) {
+	data := map[interface{}]string{
+		// Standard JS types
+		js.Undefined:    "undefined",
+		nil:             "object",
+		true:            "boolean",
+		false:           "boolean",
+		12345:           "number",
+		"one two three": "string",
+		js.Global.Call:  "function",
+		js.Global:       "object",
+	}
+	// Check whether the JS interpretor supports the 'symbol' type (Node >= 0.12)
+	if TypeOf(js.Global.Get("Symbol")) == "function" {
+		symbol := js.Global.Call("Symbol", "foo")
+		data[&symbol] = "symbol"
+	}
+	for value, expected := range data {
+		result := TypeOf(value)
+		if result != expected {
+			t.Fatalf("Typeof(%s) returned %s, not %s", value, result, expected)
+		}
+	}
+
+	if to := TypeOf(map[string]string{}); to != "object" {
+		t.Fatalf("Obscure type not recognized as object")
+	}
+	if to := TypeOf(js.Object{}); to != "object" {
+		t.Fatal("Invalid/empty JS object not recognized as object")
+	}
+
 }


### PR DESCRIPTION
<strike>This is a work in progress, and not yet ready to merge.</strike>

I'm curious whether this is a good idea.  I remember reading somewhere (I can't find it now) that Richard suggested "manual" reflection on `js.Object`s to determine their type (i.e. checking for the existence of object methods as evidence for the object's type).  The approach in this PR seems far easier to me when dealing with primitive types, and I suspect more efficient in many cases.

My questions:

1. Is it even a good idea to expose JS's `typeof` to Go?  Perhaps this has been discussed somewhere I haven't seen.
2. If it is good/useful, is my approach the best one? (i.e. wrapping the `typeof` operator in a function which is `eval`ed).  The eval runs only once, so the normal efficiency concerns of 'eval' shouldn't matter too much here. But perhaps there are other drawbacks I haven't considered.

For background, the reason I care about this is that I have a jQuery Mobile event handler which passes either a DOM object or a URL string as one argument to a particular callback.  At the moment, I'm determining the object type by comparing its `.String()` output to `[object Object]`, which works in my case (since a URL ought never equal that string), but direct access to `typeof` seems more fool-proof, and much simpler than writing complex heuristics in my code.

If it is determined that this approach is basically sound, I still need to add additional error checking before merging. It's presently easy to crash the Typeof() function by passing certain JS-unfriendly data structures (e.g. `map[string]string{}` or even `js.Object{}`)