### PR TITLE
jsbuiltin_test.go: Fix invalid format for build constraint comment.

### DIFF
--- a/jsbuiltin_test.go
+++ b/jsbuiltin_test.go
@@ -1,4 +1,5 @@
 // +build js
+
 package jsbuiltin
 
 import (


### PR DESCRIPTION
The blank line is mandatory, not optional. See https://godoc.org/go/build#hdr-Build_Constraints for the specification of build constraint comments:

> To distinguish build constraints from package documentation, a series of build constraints must be followed by a blank line.