### PR TITLE
Remove js build tag

### DIFF
--- a/jsbuiltin.go
+++ b/jsbuiltin.go
@@ -1,5 +1,3 @@
-// +build js
-
 // Package jsbuiltin provides minimal wrappers around some JavasScript
 // built-in functions.
 package jsbuiltin


### PR DESCRIPTION
Remove the build tag so things compile even when standard go tools are used instead of gopherJS specific ones